### PR TITLE
Simple whitespace change to retrigger deploy

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -1,5 +1,4 @@
 (function($) {
-
 	/**
 	 * Generate an indented list of links from a nav. Meant for use with panel().
 	 * @return {jQuery} jQuery object.


### PR DESCRIPTION
Just a simple whitespace change to try getting github pages to work after I had made the repo private. I didnt realize that I guess you can't do that if you're on the freebie plan.